### PR TITLE
Fix for updated pynello

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:2.7 
-MAINTAINER Michael Fuchs <fuchsmi@ggmail.com>
+MAINTAINER MAINTAINER Peter Salanki <peter@salanki.st>
 
 RUN apt-get update && apt-get install -y -q --no-install-recommends zip libsasl2-dev python-dev libldap2-dev libssl-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:2.7 
-MAINTAINER Peter Salanki <peter@salanki.st>
+MAINTAINER Michael Fuchs <fuchsmi@ggmail.com>
 
 RUN apt-get update && apt-get install -y -q --no-install-recommends zip libsasl2-dev python-dev libldap2-dev libssl-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:2.7 
-MAINTAINER MAINTAINER Peter Salanki <peter@salanki.st>
+MAINTAINER Peter Salanki <peter@salanki.st>
 
 RUN apt-get update && apt-get install -y -q --no-install-recommends zip libsasl2-dev python-dev libldap2-dev libssl-dev
 

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Run as Docker container
 
 .. code:: bash
 
-  docker run --name nello -d --restart=always -e NELLO_USERNAME=robot@account.com -e NELLO_PASSWORD=password -e MQTT_TOPIC=home/nello -e MQTT_BROKER=localhost salanki/nello-mqtt:latest
+  docker run --name nello -d --restart=always -e NELLO_USERNAME=robot@account.com -e NELLO_PASSWORD=password -e MQTT_TOPIC=home/nello -e MQTT_BROKER=localhost -e MQTT_USER=myusernmae -e MQTT_PASSWORD=mysecret salanki/nello-mqtt:latest
 
 Usage with OpenHAB
 -----------

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Nello will publish all locations to the topic on connect, and also print to cons
 
 Create a separate account for this integration or you will be constantly logged out from the nello app.
 
-Thanks to Philipp Schmitt for `pynello <https://github.com/pschmitt/pynello>`_.
+Nello-mqtt uses the the deprivated private from pynello. Thanks to Philipp Schmitt for `pynello <https://github.com/pschmitt/pynello>`_.
 
 Run as Docker container
 -----------

--- a/nello.py
+++ b/nello.py
@@ -38,6 +38,7 @@ client = mqtt.Client()
 client.on_connect = on_connect
 client.on_message = on_message
 
+client.username_pw_set(os.environ['MQTT_USER'], os.environ['MQTT_PASSWORD'])
 client.connect(os.environ['MQTT_BROKER'], port, 60)
 
 client.loop_forever()

--- a/nello.py
+++ b/nello.py
@@ -1,6 +1,6 @@
 import os
 import json
-from pynello import Nello
+from pynello.private import Nello
 import paho.mqtt.client as mqtt
 
 n = Nello(username=os.environ['NELLO_USERNAME'], password=os.environ['NELLO_PASSWORD'])

--- a/nello.py
+++ b/nello.py
@@ -38,7 +38,9 @@ client = mqtt.Client()
 client.on_connect = on_connect
 client.on_message = on_message
 
-client.username_pw_set(os.environ['MQTT_USER'], os.environ['MQTT_PASSWORD'])
+if os.environ.get('MQTT_USER', None) is not None:
+    client.username_pw_set(os.environ['MQTT_USER'], os.environ['MQTT_PASSWORD'])
+    
 client.connect(os.environ['MQTT_BROKER'], port, 60)
 
 client.loop_forever()


### PR DESCRIPTION
Pynello supports now two types of APIs. The old deprivated private API and a new public API. With the updated import nello-mqtt works now. Thanks